### PR TITLE
criteria were being passed as the nonexistent second argument to find…

### DIFF
--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -25,7 +25,7 @@ module.exports = {
           }
           // TODO lifted far too much code from the jqtree route,
           // refactor to share code. However note property name differences
-          return self.findForRestApi(req, { level: 0 }).children({ depth: 1000, published: null, trash: false, orphan: null, joins: false, areas: false, permission: false }).toObject(function(err, page) {
+          return self.findForRestApi(req).and({ level: 0 }).children({ depth: 1000, published: null, trash: false, orphan: null, joins: false, areas: false, permission: false }).toObject(function(err, page) {
             if (err) {
               console.error(err);
               return res.status(500).send({ error: 'error' });


### PR DESCRIPTION
…ForRestApi, which got lucky in the unit tests but not in practice with client. Fixed by chaining and() properly.