### PR TITLE
Pass options.restApi.safeFilters to cursor safeFilters method

### DIFF
--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -160,7 +160,7 @@ module.exports = {
         which = 'manage';
       }
       var cursor = self.find(req, {})
-        .safeFilters(options.piecesFilters)
+        .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
 
       var perPage = cursor.get('perPage');

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -14,7 +14,7 @@ module.exports = {
       }
       var baseEndpoint = restApi.endpoint;
       var endpoint = baseEndpoint + '/' + (options.restApi.name || self.__meta.name);
-      
+
       // GET many
       self.apos.app.get(endpoint, function(req, res) {
         var cursor = self.findForRestApi(req);
@@ -25,7 +25,7 @@ module.exports = {
           }
           return res.send(result);
         });
-        
+
         function countPieces(callback) {
           return cursor.toCount(function(err, count) {
             if (err) {
@@ -56,7 +56,7 @@ module.exports = {
             return restApi.apiRender(req, self, piece, 'piece', callback);
           }, callback);
         }
-        
+
       });
 
       // GET one
@@ -96,7 +96,7 @@ module.exports = {
           return restApi.apiRender(req, self, piece, 'piece', callback);
         }
       });
-      
+
       // POST one
       self.apos.app.post(endpoint, function(req, res) {
         return self.convertInsertAndRefresh(req, function(req, res, err, piece) {
@@ -153,13 +153,16 @@ module.exports = {
       });
 
     };
-    
+
     self.findForRestApi = function(req) {
       var which = 'public';
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
       }
-      var cursor = self.find(req, {}).queryToFilters(req.query, which);
+      var cursor = self.find(req, {})
+        .safeFilters(options.piecesFilters)
+        .queryToFilters(req.query, which);
+
       var perPage = cursor.get('perPage');
       var maxPerPage = options.restApi.maxPerPage || 50;
       if ((!perPage) || (perPage > maxPerPage)) {
@@ -167,7 +170,7 @@ module.exports = {
       }
       return cursor;
     };
-    
+
     self.modulesReady = function() {
       var restApi = self.apos.modules['apostrophe-headless'];
       self.addRestApiRoutes();


### PR DESCRIPTION
Fixes #14 

Allows defining a list of safe filters that can be used to filter through the REST API.

```
'people': {
    extend: 'apostrophe-pieces',
    name: 'people',
    restApi: {
      safeFilters: ['name', 'bio']
    }    
  },
```

Now you can pass a name filter as a query string:
`/api/v1/people?name=marjan`
