### PR TITLE
Allow "includeChildren" parameter via restApi request.

### DIFF
--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -424,7 +424,16 @@ module.exports = {
     };
     
     self.findForRestApi = function(req) {
-      return self.find(req).ancestors(true).children(true).published(null);
+      var includeChildren = true; // By default
+      if (req.query.includeChildren === "false") {
+        // Not sanitizing because the incoming value is never userd
+        includeChildren = !includeChildren;
+      }
+      return self
+        .find(req)
+        .ancestors(true)
+        .children(includeChildren) // Use the calculated value
+        .published(null);
     };
 
     var superModulesReady = self.modulesReady; 


### PR DESCRIPTION
This change allows API users to limit their response to the page requested. By default it maintains .children(true), but can be changed by passing a URL parameter of ?includeChildren=false.