### PR TITLE
restrict GET routes with permission if needed and add "private" property

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ You can also pass options for the REST API:x
       // Allow the public API to invoke additional
       // cursor filters. Note that most schema
       // fields have a cursor filter available
-      safeFilters: [ 'slug' ]
+      safeFilters: [ 'slug' ],
+      // Restrict GET routes to users with correct permission (false by default)
+      addPermissionToGetRoutes: true
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also pass options for the REST API:
       // fields have a cursor filter available
       safeFilters: [ 'slug' ],
       // Restrict GET routes to users with correct permission (false by default)
-      getRequiredEditPermission: true
+      getRequiresEditPermission: true
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ To call most filters from the public API, you will need to use the `safeFilters`
 }
 ```
 
-You can restrict what fields to send by adding `private: true` to a specific field. If only logged-out users should not see a specific field, but logged-in users should, you can pass the option `privateOnlyForPublic: true`. 
+You can restrict what fields to send by adding `api: false` to a specific field. If only logged-out users should not see a specific field, but logged-in users should, you can pass the option `api: 'loginRequired'`. 
 
 ```javascript
 {
   name: 'specificField',
   label: 'Specific Field',
   type: 'string',
-  private: true
+  api: false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ modules: {
 
 ### Configuration options
 
-You can also pass options for the REST API:x
+You can also pass options for the REST API:
 
 ```javascript
   'products': {
@@ -51,7 +51,7 @@ You can also pass options for the REST API:x
       // fields have a cursor filter available
       safeFilters: [ 'slug' ],
       // Restrict GET routes to users with correct permission (false by default)
-      addPermissionToGetRoutes: true
+      getRequiredEditPermission: true
     }
   }
 }
@@ -94,6 +94,17 @@ To call most filters from the public API, you will need to use the `safeFilters`
     // called 'color' and 'brand' in your schema
     safeFilters: [ 'slug', 'color', 'brand' ]
   }
+}
+```
+
+You can restrict what fields to send by adding `private: true` to a specific field. If only logged-out users should not see a specific field, but logged-in users should, you can pass the option `privateOnlyForPublic: true`. 
+
+```javascript
+{
+  name: 'specificField',
+  label: 'Specific Field',
+  type: 'string',
+  private: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To call most filters from the public API, you will need to use the `safeFilters`
 }
 ```
 
-You can restrict what fields to send by adding `api: false` to a specific field. If only logged-out users should not see a specific field, but logged-in users should, you can pass the option `api: 'loginRequired'`. 
+You can restrict what fields to send by adding `api: false` to a specific field. If only logged-out users should not see a specific field, but logged-in users should, you can pass the option `api: 'editPermissionRequired'`. 
 
 ```javascript
 {

--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -425,7 +425,7 @@ module.exports = {
     
     self.findForRestApi = function(req) {
       var cursor =  self.find(req).ancestors(true).children(true).published(null);
-      if (options.restApi.getRequiredEditPermission) {
+      if (options.restApi.getRequiresEditPermission) {
         cursor.permission('edit');
       }
       return cursor;

--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -424,7 +424,11 @@ module.exports = {
     };
     
     self.findForRestApi = function(req) {
-      return self.find(req).ancestors(true).children(true).published(null).permission(options.restApi.addPermissionToGetRoutes && 'edit');
+      var cursor =  self.find(req).ancestors(true).children(true).published(null);
+      if (options.restApi.getRequiredEditPermission) {
+        cursor.permission('edit');
+      }
+      return cursor;
     };
 
     var superModulesReady = self.modulesReady; 

--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -424,7 +424,7 @@ module.exports = {
     };
     
     self.findForRestApi = function(req) {
-      return self.find(req).ancestors(true).children(true).published(null);
+      return self.find(req).ancestors(true).children(true).published(null).permission(options.restApi.addPermissionToGetRoutes && 'edit');
     };
 
     var superModulesReady = self.modulesReady; 

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -258,7 +258,8 @@ module.exports = {
       }
       var cursor = self.find(req, {})
         .safeFilters(options.restApi.safeFilters || [])
-        .queryToFilters(req.query, which);
+        .queryToFilters(req.query, which)
+        .permission(options.restApi.addPermissionToGetRoutes && 'edit');
 
       var perPage = cursor.get('perPage');
       var maxPerPage = options.restApi.maxPerPage || 50;

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -256,7 +256,16 @@ module.exports = {
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
       }
+
+      var excludedFields = {};
+      self.schema.forEach(function(field) {
+        if (field.private) {
+          excludedFields[field.name] = 0;
+        }
+      })
+      
       var cursor = self.find(req, {})
+        .projection(excludedFields)
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which)
         .permission(options.restApi.addPermissionToGetRoutes && 'edit');

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -276,7 +276,7 @@ module.exports = {
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
       
-      if (options.restApi.getRequiredEditPermission) {
+      if (options.restApi.getRequiresEditPermission) {
         cursor.permission('edit');
       }
 

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -253,22 +253,32 @@ module.exports = {
 
     self.findForRestApi = function(req) {
       var which = 'public';
+      var excludedFields = {};
+
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
+      } else {
+        self.schema.forEach(function(field) {
+          if (field.privateOnlyForPublic) {
+            excludedFields[field.name] = 0;
+          }
+        })
       }
-
-      var excludedFields = {};
+      
       self.schema.forEach(function(field) {
         if (field.private) {
           excludedFields[field.name] = 0;
         }
       })
-      
+
       var cursor = self.find(req, {})
         .projection(excludedFields)
         .safeFilters(options.restApi.safeFilters || [])
-        .queryToFilters(req.query, which)
-        .permission(options.restApi.addPermissionToGetRoutes && 'edit');
+        .queryToFilters(req.query, which);
+      
+      if (options.restApi.getRequiredEditPermission) {
+        cursor.permission('edit');
+      }
 
       var perPage = cursor.get('perPage');
       var maxPerPage = options.restApi.maxPerPage || 50;

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -259,7 +259,7 @@ module.exports = {
         which = 'manage';
       } else {
         self.schema.forEach(function(field) {
-          if (field.api === 'loginRequired') {
+          if (field.api === 'editPermissionRequired') {
             excludedFields[field.name] = 0;
           }
         })

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -259,14 +259,14 @@ module.exports = {
         which = 'manage';
       } else {
         self.schema.forEach(function(field) {
-          if (field.privateOnlyForPublic) {
+          if (field.api === 'loginRequired') {
             excludedFields[field.name] = 0;
           }
         })
       }
       
       self.schema.forEach(function(field) {
-        if (field.private) {
+        if (field.api === false) {
           excludedFields[field.name] = 0;
         }
       })

--- a/test/test.js
+++ b/test/test.js
@@ -1041,14 +1041,14 @@ describe('test apostrophe-headless', function() {
   }); 
 
   it('can GET a product without private fields', function(done) {
-    apos.modules.products.schema[0].private = true;
+    apos.modules.products.schema[0].api = false;
     var name = apos.modules.products.schema[0].name;
     return http('/api/v1/products', 'GET', {}, {}, undefined, function(err, response) {
       assert(!err);
       assert(response);
       assert(response.results);
       assert(typeof response.results[name] === 'undefined');
-      apos.modules.products.schema[0].private = false;
+      apos.modules.products.schema[0].api = true;
       done();
     });
   }); 

--- a/test/test.js
+++ b/test/test.js
@@ -1026,6 +1026,21 @@ describe('test apostrophe-headless', function() {
     });
   });
 
+  it('cannot GET a product when user has not the right permission', function(done) {
+    apos.modules.products.options.restApi = {
+      addPermissionToGetRoutes: true
+    }
+    return http('/api/v1/products', 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(response.results.length === 0);
+
+      apos.modules.products.options.restApi = true
+      done();
+    });
+  }); 
+
 });
 
 function http(url, method, query, form, bearer, extra, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -1028,7 +1028,7 @@ describe('test apostrophe-headless', function() {
 
   it('cannot GET a product when user has not the right permission', function(done) {
     apos.modules.products.options.restApi = {
-      addPermissionToGetRoutes: true
+      getRequiredEditPermission: true
     }
     return http('/api/v1/products', 'GET', {}, {}, undefined, function(err, response) {
       assert(!err);

--- a/test/test.js
+++ b/test/test.js
@@ -1028,7 +1028,7 @@ describe('test apostrophe-headless', function() {
 
   it('cannot GET a product when user has not the right permission', function(done) {
     apos.modules.products.options.restApi = {
-      getRequiredEditPermission: true
+      getRequiresEditPermission: true
     }
     return http('/api/v1/products', 'GET', {}, {}, undefined, function(err, response) {
       assert(!err);

--- a/test/test.js
+++ b/test/test.js
@@ -1035,8 +1035,20 @@ describe('test apostrophe-headless', function() {
       assert(response);
       assert(response.results);
       assert(response.results.length === 0);
+      apos.modules.products.options.restApi = true;
+      done();
+    });
+  }); 
 
-      apos.modules.products.options.restApi = true
+  it('can GET a product without private fields', function(done) {
+    apos.modules.products.schema[0].private = true;
+    var name = apos.modules.products.schema[0].name;
+    return http('/api/v1/products', 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(typeof response.results[name] === 'undefined');
+      apos.modules.products.schema[0].private = false;
       done();
     });
   }); 


### PR DESCRIPTION
Proposal to add restriction on GET routes if needed.

For a specific module, add `addPermissionToGetRoutes: true` to the `restApi` options and the GET routes (`/:module_name` and `+/:module_name/:id`) will behave as POST, asking for authorization (API key or bearer token).

`addPermissionToGetRoutes: false` behaves as if this option is not passed, so GET routes are publicly accessible (as it is today).
