### PR TITLE
Proposal to add query filters : `includeFields` and `excludeFields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ To call most filters from the public API, you will need to use the `safeFilters`
 }
 ```
 
+### Filtering fields
+
 You can restrict what fields to send by adding `api: false` to a specific schema field. If only users with editing permissions for the doc should see a specific field, you can pass the option `api: 'editPermissionRequired'`. 
 
 ```javascript
@@ -106,6 +108,21 @@ You can restrict what fields to send by adding `api: false` to a specific schema
   type: 'string',
   api: false
 }
+```
+
+Or you can require only specific fields in the GET request by adding the query filter `includeonly`: `/api/v1/products?includeonly=type,slug,name`. Excluded fields with `api: false` or `api: 'editPermissionRequired'` if appropriate will not be displayed of course.
+
+Example of a response to `/api/v1/products?includeonly=type,slug,excludedFieldInSchema`
+
+```
+[
+  {
+    _id: 'whatever_id',
+    type: 'product',
+    slug: 'product-key-product',
+    _originalWidgets: {}
+  }
+]
 ```
 
 ### Access as a logged-in user

--- a/README.md
+++ b/README.md
@@ -110,9 +110,16 @@ You can restrict what fields to send by adding `api: false` to a specific schema
 }
 ```
 
-Or you can require only specific fields in the GET request by adding the query filter `includeonly`: `/api/v1/products?includeonly=type,slug,name`. Excluded fields with `api: false` or `api: 'editPermissionRequired'` if appropriate will not be displayed of course.
+Or you can require only specific fields in the GET request by adding the query filters `includeFields` and `excludeFields`.
 
-Example of a response to `/api/v1/products?includeonly=type,slug,excludedFieldInSchema`
+Examples:
+`/api/v1/products?includeFields=type,slug,name`
+`/api/v1/products?excludeFields=type,slug,name`
+
+It is useless to use both `includeFields` and `excludeFields` in the same query, as `includeFields` has the priority over `excludeFields`.
+
+Excluded fields with `api: false` or `api: 'editPermissionRequired'` if appropriate will not be displayed of course, even if added to `includeFields`.
+Example of a response to `/api/v1/products?includeFields=type,slug,excludedFieldInSchema`
 
 ```
 [

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -254,13 +254,13 @@ module.exports = {
     self.findForRestApi = function(req) {
       var which = 'public';
       var projection = {};
-      var include = false;
+      var includeFromQuery = false;
 
-      if (req.query.includeonly) {
-        var includeFields = req.query.includeonly.split(',');
+      if (req.query.includeFields) {
+        var includeFields = req.query.includeFields.split(',');
         includeFields.forEach(function(field) {
           projection[field] = 1;
-          include = true;
+          includeFromQuery = true;
         })
       }
 
@@ -273,17 +273,24 @@ module.exports = {
           }
         })
       }
-      
+
       self.schema.forEach(function(field) {
         if (field.api === false) {
           removeKey(field);
         }
       })
 
-      // add "exclude" fields only if "includeonly" fields are not required,
+      if (!includeFromQuery && req.query.excludeFields) {
+        var excludeFields = req.query.excludeFields.split(',');
+        excludeFields.forEach(function(field) {
+          projection[field] = 0;
+        })
+      }
+
+      // add "exclude" fields only if "includeFields" fields are not required,
       // because Mongo cannot handle both at the same time
       function removeKey(field) {
-        include || projection.hasOwnProperty(field.name)
+        includeFromQuery || projection.hasOwnProperty(field.name)
           ? delete projection[field.name]
           : projection[field.name] = 0;
         return projection;

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -281,7 +281,7 @@ module.exports = {
       })
 
       if (!includeFromQuery && req.query.excludeFields) {
-        var excludeFields = req.query.excludeFields.split(',');
+        var excludeFields = self.apos.launder.string(req.query.excludeFields).split(',');
         excludeFields.forEach(function(field) {
           projection[field] = 0;
         })

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -257,7 +257,7 @@ module.exports = {
       var includeFromQuery = false;
 
       if (req.query.includeFields) {
-        var includeFields = req.query.includeFields.split(',');
+        var includeFields = self.apos.launder.string(req.query.includeFields).split(',');
         includeFields.forEach(function(field) {
           projection[field] = 1;
           includeFromQuery = true;

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -253,26 +253,44 @@ module.exports = {
 
     self.findForRestApi = function(req) {
       var which = 'public';
-      var excludedFields = {};
+      var projection = {};
+      var include = false;
+
+      if (req.query.includeonly) {
+        var includeFields = req.query.includeonly.split(',');
+        includeFields.forEach(function(field) {
+          projection[field] = 1;
+          include = true;
+        })
+      }
 
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
       } else {
         self.schema.forEach(function(field) {
           if (field.api === 'editPermissionRequired') {
-            excludedFields[field.name] = 0;
+            removeKey(field);
           }
         })
       }
       
       self.schema.forEach(function(field) {
         if (field.api === false) {
-          excludedFields[field.name] = 0;
+          removeKey(field);
         }
       })
 
+      // add "exclude" fields only if "includeonly" fields are not required,
+      // because Mongo cannot handle both at the same time
+      function removeKey(field) {
+        include || projection.hasOwnProperty(field.name)
+          ? delete projection[field.name]
+          : projection[field.name] = 0;
+        return projection;
+      }
+
       var cursor = self.find(req, {})
-        .projection(excludedFields)
+        .projection(projection)
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
       

--- a/test/test.js
+++ b/test/test.js
@@ -1053,16 +1053,61 @@ describe('test apostrophe-headless', function() {
     });
   }); 
 
-  it('can GET a product with only some fields but not excluded fields', function(done) {
+  it('can GET a product with only some fields and includeFields has the priority over excludeFields', function(done) {
     apos.modules.products.schema[0].api = false;
     var name = apos.modules.products.schema[0].name;
-    return http('/api/v1/products?includeonly=slug,type,'+name, 'GET', {}, {}, undefined, function(err, response) {
+    return http('/api/v1/products?includeFields=slug,type&excludeFields=slug,type', 'GET', {}, {}, undefined, function(err, response) {
       assert(!err);
       assert(response);
       assert(response.results);
       assert(typeof response.results[0].slug === 'string');
       assert(typeof response.results[0][name] === 'undefined');
       assert(typeof response.results[0].published === 'undefined');
+      apos.modules.products.schema[0].api = true;
+      done();
+    });
+  }); 
+
+  it('can GET a product with only some fields but an excluded field from schema is always excluded', function(done) {
+    apos.modules.products.schema[0].api = false;
+    var name = apos.modules.products.schema[0].name;
+    return http('/api/v1/products?includeFields=slug,type,' + name, 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(typeof response.results[0].slug === 'string');
+      assert(typeof response.results[0][name] === 'undefined');
+      assert(typeof response.results[0].published === 'undefined');
+      apos.modules.products.schema[0].api = true;
+      done();
+    });
+  }); 
+
+  it('can GET a product with only some fields excluded', function(done) {
+    apos.modules.products.schema[0].api = false;
+    var name = apos.modules.products.schema[0].name;
+    return http('/api/v1/products?excludeFields=slug,type', 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(typeof response.results[0].slug === 'undefined');
+      assert(typeof response.results[0][name] === 'undefined');
+      assert(typeof response.results[0].published === 'boolean');
+      apos.modules.products.schema[0].api = true;
+      done();
+    });
+  }); 
+
+  it('can GET a product with only some fields excluded and an excluded field from schema is still excluded', function(done) {
+    apos.modules.products.schema[0].api = false;
+    var name = apos.modules.products.schema[0].name;
+    return http('/api/v1/products?excludeFields=slug,type,' + name, 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(typeof response.results[0].slug === 'undefined');
+      assert(typeof response.results[0][name] === 'undefined');
+      assert(typeof response.results[0].published === 'boolean');
       apos.modules.products.schema[0].api = true;
       done();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -1047,7 +1047,22 @@ describe('test apostrophe-headless', function() {
       assert(!err);
       assert(response);
       assert(response.results);
-      assert(typeof response.results[name] === 'undefined');
+      assert(typeof response.results[0][name] === 'undefined');
+      apos.modules.products.schema[0].api = true;
+      done();
+    });
+  }); 
+
+  it('can GET a product with only some fields but not excluded fields', function(done) {
+    apos.modules.products.schema[0].api = false;
+    var name = apos.modules.products.schema[0].name;
+    return http('/api/v1/products?includeonly=slug,type,'+name, 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      assert(typeof response.results[0].slug === 'string');
+      assert(typeof response.results[0][name] === 'undefined');
+      assert(typeof response.results[0].published === 'undefined');
       apos.modules.products.schema[0].api = true;
       done();
     });


### PR DESCRIPTION
Even if it is possible to restrict what fields to display through the schema (aka `api: false`), sometimes a query needs a whole document, and sometimes another query needs only a few fields from the same document.

For performance reason, I suggest to add a query filter `includeonly`.
Example: `/api/v1/products?includeonly=type,slug,excludedFieldInSchema` will return 
```
[
  {
    _id: 'whatever_id',
    type: 'product',
    slug: 'product-key-product',
    _originalWidgets: {}
  }
]
```
(that is to say required fields but not previously excluded fields in the schema).

I added a test and updated the documentation too.