### PR TITLE
Exclude join if needed

### DIFF
--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -52,7 +52,6 @@ module.exports = {
 
         function renderPieces(callback) {
           return async.eachSeries(result.results, function(piece, callback) {
-            self.cleanPiece(req, piece, self.schema);
             var restApi = self.apos.modules['apostrophe-headless'];
             return restApi.apiRender(req, self, piece, 'piece', callback);
           }, callback);
@@ -87,7 +86,6 @@ module.exports = {
               return callback('notfound');
             }
             piece = _piece;
-            self.cleanPiece(req, piece, self.schema);
             // Attach `_url` and `_urls` properties
             self.apos.attachments.all(piece, { annotate: true });
             return callback(null);
@@ -156,7 +154,7 @@ module.exports = {
       // of a join. For instance, if a `joinByArray` field is named
       // `_people`, and `idsField` has not been set to the contrary,
       // you can append the `_id`s of additional people
-      // to the `peopleIds` property using `$addToSet`.
+      // to the `peopleIds` property using `$addToSet`. 
       //
       // `patch` calls are guaranteed to be atomic with regard to
       // other `patch` operations. That is, if two `patch` operations
@@ -164,12 +162,12 @@ module.exports = {
       // property updates are guaranteed to make it through. If
       // two `patch` operations attempt to `$push` to the same
       // array, the first to begin will append its items first.
-
+      
       self.apos.app.patch(endpoint + '/:id', function(req, res) {
         var id = self.apos.launder.id(req.params.id);
         return self.restPutOrPatch(req, id, 'patch');
       });
-
+      
       // Implementation detail of the PUT and PATCH methods
       // (see above).
       //
@@ -257,6 +255,7 @@ module.exports = {
       var which = 'public';
       var projection = {};
       var includeFromQuery = false;
+      var joinsToRemove = [];
 
       if (req.query.includeFields) {
         var includeFields = self.apos.launder.string(req.query.includeFields).split(',');
@@ -268,7 +267,19 @@ module.exports = {
 
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
+      } else {
+        self.schema.forEach(function(field) {
+          if (field.api === 'editPermissionRequired') {
+            removeKey(field);
+          }
+        })
       }
+
+      self.schema.forEach(function(field) {
+        if (field.api === false) {
+          removeKey(field);
+        }
+      })
 
       if (!includeFromQuery && req.query.excludeFields) {
         var excludeFields = self.apos.launder.string(req.query.excludeFields).split(',');
@@ -277,11 +288,48 @@ module.exports = {
         })
       }
 
+      // add "exclude" fields only if "includeFields" fields are not required,
+      // because Mongo cannot handle both at the same time
+      function removeKey(field) {
+        if (includeFromQuery || projection.hasOwnProperty(field.name)) {
+          delete projection[field.name];
+          if (field.type.match(/join/)) {
+            joinsToRemove.push(field);
+          }
+        } else {
+          projection[field.name] = 0;
+          if (field.type.match(/join/)) {
+            removeJoin(field);
+          }
+        }
+
+        return projection;
+      }
+
+      function removeJoin(field) {
+        if (field.relationship) {
+          projection[field.relationshipsField] = 0;
+        }
+        if (field.idsField) {
+          projection[field.idsField] = 0;
+        }
+        if (field.idField) {
+          projection[field.idField] = 0;
+        }
+      }
+
+      // if a forbidden join field is the only one included in the query, remove it from the cursor
+      if (_.isEmpty(projection) && joinsToRemove.length > 0) {
+        joinsToRemove.forEach(function(join) {
+          removeJoin(join);
+        })
+      }
+
       var cursor = self.find(req, {})
         .projection(projection)
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
-
+      
       if (options.restApi.getRequiresEditPermission) {
         cursor.permission('edit');
       }
@@ -299,38 +347,5 @@ module.exports = {
       self.addRestApiRoutes();
       restApi.registerModule(self);
     };
-
-    self.cleanPiece = function(req, piece, schema) {
-      schema.forEach(function(field) {
-        // for every field with relationship, analyze if any field inside needs to be removed
-        if (field.relationship && piece[field.name]) {
-          piece[field.name].forEach(function(element) {
-            self.cleanPiece(req, element.relationship, field.relationship);
-          })
-        }
-
-        if (field.api === false) {
-          cleanRelationship(field);
-          piece[field.name] = undefined;
-        }
-      })
-
-      if (!self.apos.permissions.can(req, 'edit-' + self.name)) {
-        schema.forEach(function(field) {
-          if (field.api === 'editPermissionRequired') {
-            cleanRelationship(field);
-            piece[field.name] = undefined;
-          }
-        })
-      }
-
-      // if the field to be removed has relationship, remove it also
-      function cleanRelationship (field) {
-        if (field.relationship && piece[field.name]) {
-          piece[field.relationshipsField] = undefined;
-          piece[field.idsField] = undefined;
-        }
-      }
-    }
   }
 };

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -255,7 +255,8 @@ module.exports = {
       var which = 'public';
       var projection = {};
       var includeFromQuery = false;
-      var joinsToRemove = [];
+      var joins = [];
+      var joinsToExclude = [];
 
       if (req.query.includeFields) {
         var includeFields = self.apos.launder.string(req.query.includeFields).split(',');
@@ -279,6 +280,9 @@ module.exports = {
         if (field.api === false) {
           removeKey(field);
         }
+        if (field.type.match(/join/)) {
+          joins.push(field.name);
+        }
       })
 
       if (!includeFromQuery && req.query.excludeFields) {
@@ -294,39 +298,30 @@ module.exports = {
         if (includeFromQuery || projection.hasOwnProperty(field.name)) {
           delete projection[field.name];
           if (field.type.match(/join/)) {
-            joinsToRemove.push(field);
+            joinsToExclude.push(field.name);
           }
         } else {
           projection[field.name] = 0;
           if (field.type.match(/join/)) {
-            removeJoin(field);
+            if (field.relationship) {
+              projection[field.relationshipsField] = 0;
+            }
+            if (field.idsField) {
+              projection[field.idsField] = 0;
+            }
+            if (field.idField) {
+              projection[field.idField] = 0;
+            }
           }
         }
 
         return projection;
       }
 
-      function removeJoin(field) {
-        if (field.relationship) {
-          projection[field.relationshipsField] = 0;
-        }
-        if (field.idsField) {
-          projection[field.idsField] = 0;
-        }
-        if (field.idField) {
-          projection[field.idField] = 0;
-        }
-      }
-
-      // if a forbidden join field is the only one included in the query, remove it from the cursor
-      if (_.isEmpty(projection) && joinsToRemove.length > 0) {
-        joinsToRemove.forEach(function(join) {
-          removeJoin(join);
-        })
-      }
-
+      var joinsToInclude = _.difference(joins, joinsToExclude);
       var cursor = self.find(req, {})
         .projection(projection)
+        .joins(joinsToInclude)
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
       

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -52,6 +52,7 @@ module.exports = {
 
         function renderPieces(callback) {
           return async.eachSeries(result.results, function(piece, callback) {
+            self.cleanPiece(req, piece, self.schema);
             var restApi = self.apos.modules['apostrophe-headless'];
             return restApi.apiRender(req, self, piece, 'piece', callback);
           }, callback);
@@ -86,6 +87,7 @@ module.exports = {
               return callback('notfound');
             }
             piece = _piece;
+            self.cleanPiece(req, piece, self.schema);
             // Attach `_url` and `_urls` properties
             self.apos.attachments.all(piece, { annotate: true });
             return callback(null);
@@ -154,7 +156,7 @@ module.exports = {
       // of a join. For instance, if a `joinByArray` field is named
       // `_people`, and `idsField` has not been set to the contrary,
       // you can append the `_id`s of additional people
-      // to the `peopleIds` property using `$addToSet`. 
+      // to the `peopleIds` property using `$addToSet`.
       //
       // `patch` calls are guaranteed to be atomic with regard to
       // other `patch` operations. That is, if two `patch` operations
@@ -162,12 +164,12 @@ module.exports = {
       // property updates are guaranteed to make it through. If
       // two `patch` operations attempt to `$push` to the same
       // array, the first to begin will append its items first.
-      
+
       self.apos.app.patch(endpoint + '/:id', function(req, res) {
         var id = self.apos.launder.id(req.params.id);
         return self.restPutOrPatch(req, id, 'patch');
       });
-      
+
       // Implementation detail of the PUT and PATCH methods
       // (see above).
       //
@@ -266,19 +268,7 @@ module.exports = {
 
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
-      } else {
-        self.schema.forEach(function(field) {
-          if (field.api === 'editPermissionRequired') {
-            removeKey(field);
-          }
-        })
       }
-
-      self.schema.forEach(function(field) {
-        if (field.api === false) {
-          removeKey(field);
-        }
-      })
 
       if (!includeFromQuery && req.query.excludeFields) {
         var excludeFields = self.apos.launder.string(req.query.excludeFields).split(',');
@@ -287,20 +277,11 @@ module.exports = {
         })
       }
 
-      // add "exclude" fields only if "includeFields" fields are not required,
-      // because Mongo cannot handle both at the same time
-      function removeKey(field) {
-        includeFromQuery || projection.hasOwnProperty(field.name)
-          ? delete projection[field.name]
-          : projection[field.name] = 0;
-        return projection;
-      }
-
       var cursor = self.find(req, {})
         .projection(projection)
         .safeFilters(options.restApi.safeFilters || [])
         .queryToFilters(req.query, which);
-      
+
       if (options.restApi.getRequiresEditPermission) {
         cursor.permission('edit');
       }
@@ -318,5 +299,38 @@ module.exports = {
       self.addRestApiRoutes();
       restApi.registerModule(self);
     };
+
+    self.cleanPiece = function(req, piece, schema) {
+      schema.forEach(function(field) {
+        // for every field with relationship, analyze if any field inside needs to be removed
+        if (field.relationship && piece[field.name]) {
+          piece[field.name].forEach(function(element) {
+            self.cleanPiece(req, element.relationship, field.relationship);
+          })
+        }
+
+        if (field.api === false) {
+          cleanRelationship(field);
+          piece[field.name] = undefined;
+        }
+      })
+
+      if (!self.apos.permissions.can(req, 'edit-' + self.name)) {
+        schema.forEach(function(field) {
+          if (field.api === 'editPermissionRequired') {
+            cleanRelationship(field);
+            piece[field.name] = undefined;
+          }
+        })
+      }
+
+      // if the field to be removed has relationship, remove it also
+      function cleanRelationship (field) {
+        if (field.relationship && piece[field.name]) {
+          piece[field.relationshipsField] = undefined;
+          piece[field.idsField] = undefined;
+        }
+      }
+    }
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1177,6 +1177,19 @@ describe('test apostrophe-headless', function() {
     });
   }); 
 
+  it('can GET a product without excluded joins even if included in query', function(done) {
+    return http('/api/v1/products?includeFields=slug,type,_articles', 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      var product = _.find(response.results, { slug: 'product-key-product-with-join' });
+      assert(typeof product.type === 'string');
+      assert(typeof product.slug === 'string');
+      assert(typeof product['_articles'] === 'undefined');
+      done();
+    });
+  }); 
+
   it('can GET a product with joins', function(done) {
     var articleInSchema = _.find(apos.modules.products.schema, { name: '_articles' })
     articleInSchema.api = true
@@ -1185,6 +1198,23 @@ describe('test apostrophe-headless', function() {
       assert(response);
       assert(response.results);
       var product = _.find(response.results, { slug: 'product-key-product-with-join' });
+      assert(Array.isArray(product['_articles']));
+      assert(product['_articles'].length === 1);
+      articleInSchema.api = 'editPermissionRequired';
+      done();
+    });
+  }); 
+
+  it('can GET a product with included joins', function(done) {
+    var articleInSchema = _.find(apos.modules.products.schema, { name: '_articles' })
+    articleInSchema.api = true
+    return http('/api/v1/products?includeFields=slug,type,_articles', 'GET', {}, {}, undefined, function(err, response) {
+      assert(!err);
+      assert(response);
+      assert(response.results);
+      var product = _.find(response.results, { slug: 'product-key-product-with-join' });
+      assert(typeof product.type === 'string');
+      assert(typeof product.slug === 'string');
       assert(Array.isArray(product['_articles']));
       assert(product['_articles'].length === 1);
       articleInSchema.api = 'editPermissionRequired';


### PR DESCRIPTION
In previous PRs (https://github.com/apostrophecms/apostrophe-headless/pull/23 and https://github.com/apostrophecms/apostrophe-headless/pull/25), I added an option `api` to fields to hide them in GET requests.

But I did not check joins, and I realized it was not working (so joins were still sent in the response with `api: false`or `api: 'editPermissionRequired'` in the schema). I think this is because joins are fetched when the cursor is called.

Here is my proposal to solve this (and even to be able to hide only a relation in a join field if needed). The downside of this solution is this is done after the `findForRestApi` function. 