### PR TITLE
always fetch docPermissions to annotate pieces with _edit (but do not…

### DIFF
--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -74,6 +74,25 @@ module.exports = {
             }
             // Attach `_url` and `_urls` properties
             self.apos.attachments.all(pieces, { annotate: true });
+            pieces.forEach(function(piece) {
+              if (!piece._edit) {
+                // Filter out editPermissions properties, where appropriate
+                self.schema.forEach(function(field) {
+                  if (field.api === 'editPermissionRequired') {
+                    delete piece[field.name];
+                  }
+                });
+                // If you can't edit, it is none of your business who else can
+                delete piece.docPermissions;
+              }
+              // To avoid situations that confuse developers, such as joins not
+              // working or _url not populating, some fields like tags or type are
+              // not excluded at the mongo level. Instead, delete them before
+              // transmission
+              _.each(req.excludeFields, function(field) {
+                delete piece[field];
+              });
+            });
             result.results = pieces;
             return callback(null);
           });
@@ -288,21 +307,18 @@ module.exports = {
       var joinsToExclude = [];
 
       if (req.query.includeFields) {
+        // Always retrieve information necessary to annotate
+        // what is editable and what is not
+        projection.docPermissions = 1;
         var includeFields = self.apos.launder.string(req.query.includeFields).split(',');
         includeFields.forEach(function(field) {
           projection[field] = 1;
           includeFromQuery = true;
-        })
+        });
       }
 
       if (self.apos.permissions.can(req, 'edit-' + self.name)) {
         which = 'manage';
-      } else {
-        self.schema.forEach(function(field) {
-          if (field.api === 'editPermissionRequired') {
-            removeKey(field);
-          }
-        })
       }
 
       self.schema.forEach(function(field) {
@@ -316,15 +332,19 @@ module.exports = {
             if (subField.type.match(/join/)) {
               joins.push(field.name + '.' + subField.name);
             }
-          })
+          });
         }
-      })
+      });
 
       if (!includeFromQuery && req.query.excludeFields) {
-        var excludeFields = self.apos.launder.string(req.query.excludeFields).split(',');
-        excludeFields.forEach(function(field) {
-          projection[field] = 0;
-        })
+        req.excludeFields = self.apos.launder.string(req.query.excludeFields).split(',');
+        req.excludeFields.forEach(function(field) {
+          // Excluding these fields via mongodb has side effects on joins and _url that are
+          // rarely anticipated by developers. We will delete them after the fetch
+          if ((field !== 'type') && (field !== '_id') && (field !== 'tags') && (field !== 'slug')) {
+            projection[field] = 0;
+          }
+        });
       }
 
       // add "exclude" fields only if "includeFields" fields are not required,


### PR DESCRIPTION
… return it unless we have edit privs). Never exclude _id, type, slug or tags from the mongo projection but do delete them just before returning; this fixes unexpected knock-on effects on _url, joins, etc.