### PR TITLE
Fix issue introduced in apostrophe 2.102.0 where newly inserted pieces are unpublished

### DIFF
--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -188,6 +188,12 @@ module.exports = {
             // Base the allowed schema on a generic new child of the parent page, not
             // random untrusted stuff from the browser
             var schema = manager.allowedSchema(req);
+            var keys = Object.keys(page);
+            if (_.includes(keys, 'title') && (!_.includes(keys, 'slug'))) {
+              // Let the slug be inferred from the title properly
+              keys.push('slug');
+            }
+            schema = self.apos.schemas.subset(schema, keys);
             return self.apos.schemas.convert(req, schema, 'form', page, safePage, callback);
           },
           insert: function(callback) {
@@ -358,8 +364,10 @@ module.exports = {
               if (action === 'patch') {
                 schema = restApi.subsetSchemaForPatch(schema, page);
                 restApi.implementPatchOperators(existingPage, page);
+              } else {
+                // overwrite only fields that are in the schema
+                schema = self.apos.schemas.subset(schema, Object.keys(page));
               }
-              // overwrite fields that are in the schema
               return self.apos.schemas.convert(req, schema, 'form', page, existingPage, callback);
             },
             update: function(callback) {

--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -132,6 +132,7 @@ module.exports = {
 
       // POST one
       self.apos.app.post(endpoint, function(req, res) {
+        req.convertOnlyTheseFields = Object.keys(req.body);
         return self.convertInsertAndRefresh(req, function(req, res, err, piece) {
           if (err) {
             return res.status(500).send({ error: 'error' });
@@ -265,6 +266,8 @@ module.exports = {
                 var restApi = self.apos.modules['apostrophe-headless'];
                 restApi.implementPatchOperators(_piece, req.body);
                 req.restApiPatchSchema = restApi.subsetSchemaForPatch(self.schema, req.body);
+              } else {
+                req.convertOnlyTheseFields = Object.keys(req.body);
               }
               return self.convertUpdateAndRefresh(req, function(req, res, err, _piece) {
                 return callback(err);

--- a/test/test.js
+++ b/test/test.js
@@ -903,6 +903,7 @@ describe('test apostrophe-headless', function() {
     http('/api/v1/apostrophe-pages/' + newPage._id, 'PUT', { apiKey: 'page-key' }, newPage, undefined, function(err, response) {
       assert(!err);
       assert(response.title === 'Tab One Child Three Modified');
+      assert(response.published);
       done();
     });
   });


### PR DESCRIPTION
... Unless the published property is explicitly passed, etc. A major bug in practice.