### PR TITLE
Added "sort" parameter to query processing

### DIFF
--- a/lib/modules/apostrophe-pieces-headless/index.js
+++ b/lib/modules/apostrophe-pieces-headless/index.js
@@ -415,6 +415,21 @@ module.exports = {
       if ((!perPage) || (perPage > maxPerPage)) {
         cursor.perPage(maxPerPage);
       }
+
+      var sort = req.query.sort;
+      if(sort) {
+        var sortBy = sort;
+        var sortDirection = 1;
+        if(sort.startsWith('-')) {
+          sortBy = sort.substr(1);
+          sortDirection = -1;
+        }
+        var sortExpression = {};
+        sortExpression[sortBy] = sortDirection;
+        console.log(JSON.stringify(sortExpression));
+        cursor.sort(sortExpression);
+      }
+      
       return cursor;
     };
 


### PR DESCRIPTION
The sort parameter passed to cursor on final step. Query parameter using "-" prefix to identify sorting direction.