### PR TITLE
dot notation now fully supported in PATCH operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 2.11.0
+
+* MongoDB-style "dot notation" is now properly supported in PATCH requests. That is, your request body might be:
+
+```javascript
+{
+  "body.items.0.addresses.2.street": "100 Peace Lane"
+}
+```
+
+And as long as such a path exists in the document it will be updated.
+The final path component need not already exist. The resulting document
+is still submitted through Apostrophe's normal sanitization mechanisms,
+this is not a direct MongoDB `$set` operation.
+
+* Bug fix: the use of MongoDB-style dot notation with `$pull` and other
+operators no longer incorrectly discards other subtrees of the same path.
+
 ## 2.10.0
 
 * Allows requests for pages to include `children=false` and `ancestors=false` query parameters that disable those respective properties on the response. Thanks to [Paul Grieselhuber](https://github.com/paulisloud) for the suggestion and original work on this feature.

--- a/README.md
+++ b/README.md
@@ -625,6 +625,26 @@ $pullAllById: {
 
 > Array operators can be used to manipulate `array` schema fields, the widget array of an area, or the `idsField` of a join.
 
+## Patching one subproperty
+
+You may also PATCH subproperties using MongoDB-style "dot notation."
+
+For instance your request body might look like:
+
+```javascript
+{
+  "body.items.0.addresses.2.street": "100 Peace Lane"
+}
+```
+
+As long as such a path exists in the document it will be updated.
+The final path component need not already exist. The resulting document
+is still submitted through Apostrophe's normal sanitization mechanisms,
+this is not a direct MongoDB `$set` operation.
+
+Dot notation may also be used in this manner within `$pull` and
+the other operators documented above.
+
 ## Deleting a product
 
 To delete a product, make a DELETE request. Send it to:

--- a/index.js
+++ b/index.js
@@ -329,40 +329,93 @@ module.exports = {
     };
 
     // Implementation detail, called for you by the PATCH route.
-    // Applies changes in `page` to `existingPage`, including support
-    // for the `$push`, `$pullAll`, and `$pullAllById` operators.
+    // Alters `patch` into input suitable for a `convert` call
+    // to update `existingPage` by copying content from `existingPage`
+    // based on the operators and dot notation references
+    // initially present in `patch`. When this operation is complete
+    // every top level object impacted by the patch will be present
+    // in `patch`. Implements `$push`, $pullAll` and `$pullAllById`
+    // in addition to dot notation support.
 
-    self.implementPatchOperators = function(existingPage, page) {
-      if (page.$push) {
-        append(page.$push);
-      } else if (page.$pullAll) {
-        _.each(page.$pullAll, function(val, key) {
-          _.set(page, key, _.differenceWith(_.get(existingPage, key) || [], _.get(page.$pullAll, key) || [], function(a, b) {
+    self.implementPatchOperators = function(existingPage, patch) {
+      const clonedBases = {};
+      if (patch.$push) {
+        append(patch.$push);
+      } else if (patch.$pullAll) {
+        _.each(patch.$pullAll, function(val, key) {
+          cloneOriginalBase(key);
+          set(patch, key, _.differenceWith(get(patch, key) || [], get(patch.$pullAll, key) || [], function(a, b) {
             return _.isEqual(a, b);
           }));
         });
-      } else if (page.$pullAllById) {
-        _.each(page.$pullAllById, function(val, key) {
-          _.set(page, key, _.get(existingPage, key) || []);
+      } else if (patch.$pullAllById) {
+        _.each(patch.$pullAllById, function(val, key) {
+          cloneOriginalBase(key);
           if (!Array.isArray(val)) {
             val = [ val ];
           }
-          _.set(page, key, _.differenceWith(_.get(existingPage, key) || [], _.get(page.$pullAllById, key), function(a, b) {
+          set(patch, key, _.differenceWith(get(patch, key) || [], get(patch.$pullAllById, key), function(a, b) {
             return (a._id || a.id) === b;
           }));
         });
       }
+      _.each(patch, function(val, key) {
+        if (key.charAt(0) !== '$') {
+          // Simple replacement with a dot path
+          if (key.indexOf('.') !== -1) {
+            cloneOriginalBase(key);
+            set(patch, key, val);
+          }
+        }
+      });
       function append(data) {
         _.each(data, function(val, key) {
-          _.set(page, key, _.get(existingPage, key) || []);
+          cloneOriginalBase(key);
+          set(patch, key, get(existingPage, key) || []);
           if (val && val.$each) {
-            _.set(page, key, (_.get(page, key) || []).concat(val.$each));
+            set(patch, key, (get(patch, key) || []).concat(val.$each));
           } else {
-            var existing = _.get(page, key) || [];
+            var existing = get(patch, key) || [];
             existing.push(val);
-            _.set(page, key, existing);
+            set(patch, key, existing);
           }
         });
+      }
+      function cloneOriginalBase(key) {
+        if (key.indexOf('.') === -1) {
+          // No need, we are replacing the base
+        }
+        const base = key.split('.')[0];
+        if (!clonedBases[base]) {
+          if (_.has(existingPage, base)) {
+            patch[base] = self.apos.utils.clonePermanent(existingPage[base]);
+          }
+          clonedBases[base] = true;
+        }
+      }
+
+      // mongo style dot notation, different from _.get and _.set alas
+
+      function get(o, path) {
+        var i;
+        path = path.split('.');
+        for (i = 0; (i < path.length); i++) {
+          var p = path[i];
+          o = o[p];
+        }
+        return o;
+      }
+
+      function set(o, path, v) {
+        var i;
+        var p;
+        path = path.split('.');
+        for (i = 0; (i < (path.length - 1)); i++) {
+          p = path[i];
+          o = o[p];
+        }
+        p = path[path.length - 1];
+        o[p] = v;
       }
     };
 

--- a/lib/modules/apostrophe-pages-headless/index.js
+++ b/lib/modules/apostrophe-pages-headless/index.js
@@ -370,8 +370,8 @@ module.exports = {
               schema = self.addApplyToSubpagesToSchema(schema);
               schema = self.removeParkedPropertiesFromSchema(existingPage, schema);
               if (action === 'patch') {
-                schema = restApi.subsetSchemaForPatch(schema, page);
                 restApi.implementPatchOperators(existingPage, page);
+                schema = restApi.subsetSchemaForPatch(schema, page);
               } else {
                 // overwrite only fields that are in the schema
                 schema = self.apos.schemas.subset(schema, Object.keys(page));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-headless",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Use Apostrophe as a headless CMS with REST APIs for your apps",
   "main": "index.js",
   "scripts": {
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-headless#readme",
   "dependencies": {
-    "async": "^2.5.0",
-    "bluebird": "^3.5.4",
+    "async": "^2.6.3",
+    "bluebird": "^3.7.2",
     "cors": "^2.8.4",
     "cuid": "^1.3.8",
     "express-bearer-token": "^2.1.0",
@@ -35,16 +35,16 @@
   },
   "devDependencies": {
     "apostrophe": "^2.105.0",
-    "apostrophe-workflow": "^2.19.0",
+    "apostrophe-workflow": "^2.34.1",
     "eslint": "^6.0.0",
     "eslint-config-apostrophe": "^3.1.0",
     "eslint-config-standard": "^11.0.0-beta.0",
-    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
     "fs-extra": "^4.0.2",
     "mocha": "^5.2.0",
-    "request": "^2.83.0"
+    "request": "^2.88.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1004,6 +1004,22 @@ describe('test apostrophe-headless', function() {
     });
   });
 
+  it('can patch subproperty', function(done) {
+    return http('/api/v1/apostrophe-pages/' + tabOneId, 'PATCH', { apiKey: 'page-key' }, {
+      'addresses.0.street': '100 Test Lane'
+    }, undefined, function(err, response) {
+      assert(!err);
+      assert(response.title === 'Tab One');
+      assert(response.addresses);
+      assert(response.addresses[0]);
+      assert(response.addresses[0].street === '100 Test Lane');
+      assert(response.addresses[1]);
+      assert(response.addresses[1].street === '102 Test Lane');
+      assert(!response.addresses[2]);
+      done();
+    });
+  });
+
   it('can append to addresses array', function(done) {
     return http('/api/v1/apostrophe-pages/' + tabOneId, 'PATCH', { apiKey: 'page-key' }, {
       $push: {
@@ -1016,7 +1032,7 @@ describe('test apostrophe-headless', function() {
       assert(response.title === 'Tab One');
       assert(response.addresses);
       assert(response.addresses[0]);
-      assert(response.addresses[0].street === '101 Test Lane');
+      assert(response.addresses[0].street === '100 Test Lane');
       assert(response.addresses[1]);
       assert(response.addresses[1].street === '102 Test Lane');
       assert(response.addresses[2]);


### PR DESCRIPTION
* MongoDB-style "dot notation" is now properly supported in PATCH requests. That is, your request body might be:

```javascript
{
  "body.items.0.addresses.2.street": "100 Peace Lane"
}
```

And as long as such a path exists in the document it will be updated.
The final path component need not already exist. The resulting document
is still submitted through Apostrophe's normal sanitization mechanisms,
this is not a direct MongoDB `$set` operation.

* Bug fix: the use of MongoDB-style dot notation with `$pull` and other
operators no longer incorrectly discards other subtrees of the same path.
