### PR TITLE
Enable CSRF exceptions for headless routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,8 +169,15 @@ module.exports = {
       if (req.url.substr(0, self.endpoint.length + 1) !== (self.endpoint + '/')) {
         return next();
       }
-      if (req.url === self.endpoint + '/login') {
+      const exceptions = self.apos.modules['apostrophe-express'].options.csrf && self.apos.modules['apostrophe-express'].options.csrf.exceptions
+        ? self.apos.modules['apostrophe-express'].options.csrf.exceptions
+        : [];
+      const isLogin = (req.url === self.endpoint + '/login');
+      const isCsrfException = exceptions.includes(req.url);
+
+      if (isLogin || isCsrfException) {
         // Login is exempt, chicken and egg
+        req.csrfExempt = true;
         return next();
       }
 


### PR DESCRIPTION
Hi, my colleague @ecb34 and me have noticed that adding a headless route as a CSRF exception was not working, and we have though about this aproach to solve it.